### PR TITLE
Use lazy query iterator

### DIFF
--- a/src/main/java/dynamodb/Connector.java
+++ b/src/main/java/dynamodb/Connector.java
@@ -1,19 +1,16 @@
 package dynamodb;
 
-import software.amazon.awssdk.services.dynamodb.DynamoDbClient;
-import software.amazon.awssdk.services.dynamodb.model.AttributeValue;
 import software.amazon.awssdk.services.dynamodb.model.ScanResponse;
+import software.amazon.awssdk.services.dynamodb.paginators.QueryIterable;
 import org.apache.spark.sql.sources.Filter;
 
 import java.util.List;
-import java.util.Map;
-import java.util.Optional;
 
 public interface Connector {
 
 
     ScanResponse scan(int segmentNum, List<String> columns, Filter[] filters);
-    List<Map<String, AttributeValue>> query(int segmentNum, List<String> columns, Filter[] filters);
+    QueryIterable query(int segmentNum, List<String> columns, Filter[] filters);
     boolean isFilterPushdownEnabled();
     boolean nonEmpty();
     boolean isEmpty();

--- a/src/main/java/dynamodb/DynamoQueryIndexConnector.java
+++ b/src/main/java/dynamodb/DynamoQueryIndexConnector.java
@@ -157,13 +157,12 @@ public class DynamoQueryIndexConnector extends DynamoConnector implements Serial
     }
 
     @Override
-    public List<Map<String, AttributeValue>> query(int segmentNum, List<String> columns, Filter[] filters) {
+    public QueryIterable query(int segmentNum, List<String> columns, Filter[] filters) {
         initDynamoDbClient(); // Ensure client is initialized on executor
-        List<Map<String, AttributeValue>> fullResult = new ArrayList<>();
 
         Map<String, AttributeValue> expressionValues = getExpressionAttributeValues();
 
-        QueryIterable queryIterable = dynamoDbClient.queryPaginator(queryRequest -> {
+        return dynamoDbClient.queryPaginator(queryRequest -> {
             queryRequest
                     .tableName(tableName)
                     .indexName(indexName)
@@ -184,9 +183,9 @@ public class DynamoQueryIndexConnector extends DynamoConnector implements Serial
                 List<String> projectionFields = new ArrayList<>();
 
                 for (String column : columns) {
-                        String placeholder = "#" + column;
-                        expressionAttributeNames.put(placeholder, column);
-                        projectionFields.add(placeholder);
+                    String placeholder = "#" + column;
+                    expressionAttributeNames.put(placeholder, column);
+                    projectionFields.add(placeholder);
                 }
 
                 // Set ProjectionExpression with placeholders
@@ -200,12 +199,6 @@ public class DynamoQueryIndexConnector extends DynamoConnector implements Serial
                 queryRequest.expressionAttributeValues(expressionValues);
             }
         });
-
-        for (QueryResponse page : queryIterable) {
-            fullResult.addAll(page.items());
-        }
-
-        return fullResult;
     }
 
     @Override

--- a/src/main/java/dynamodb/DynamoScanConnector.java
+++ b/src/main/java/dynamodb/DynamoScanConnector.java
@@ -2,6 +2,7 @@ package dynamodb;
 
 import software.amazon.awssdk.services.dynamodb.DynamoDbClient;
 import software.amazon.awssdk.services.dynamodb.model.*;
+import software.amazon.awssdk.services.dynamodb.paginators.QueryIterable;
 
 import java.io.Serializable;
 import java.util.List;
@@ -94,8 +95,8 @@ public class DynamoScanConnector extends DynamoConnector implements Serializable
     }
 
     @Override
-    public List<Map<String, AttributeValue>> query(int segmentNum, List<String> columns, Filter[] filters) {
-        return java.util.Collections.emptyList();
+    public QueryIterable query(int segmentNum, List<String> columns, Filter[] filters) {
+        throw new UnsupportedOperationException("Query not supported for scan connector");
     }
 
     @Override


### PR DESCRIPTION
## Summary
- return QueryIterable from DynamoQueryIndexConnector to avoid materializing full results
- stream QueryPartitionReader results page by page with rate limiting
- expose query pagination via Connector and guard scan connector

## Testing
- `mvn -q test` *(fails: Plugin net.alchim31.maven:scala-maven-plugin:4.5.6 or one of its dependencies could not be resolved: The following artifacts could not be resolved: net.alchim31.maven:scala-maven-plugin:pom:4.5.6 (absent): Could not transfer artifact net.alchim31.maven:scala-maven-plugin:pom:4.5.6 from/to central (https://repo.maven.apache.org/maven2): Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_6898cfb85ff4833288319da11694ea62