### PR TITLE
Avoid duplicate reads for query connector

### DIFF
--- a/src/main/java/dynamodb/DynamoBatchReader.java
+++ b/src/main/java/dynamodb/DynamoBatchReader.java
@@ -1,7 +1,6 @@
 package dynamodb;
 
 import dynamodb.readers.DynamoReaderFactory;
-import org.apache.commons.lang3.NotImplementedException;
 import org.apache.spark.sql.connector.expressions.Expression;
 import org.apache.spark.sql.connector.expressions.Expressions;
 import org.apache.spark.sql.connector.read.*;
@@ -11,7 +10,6 @@ import org.apache.spark.sql.sources.Filter;
 import org.apache.spark.sql.types.StructField;
 import org.apache.spark.sql.types.StructType;
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.List;
 import java.util.stream.IntStream;
 
@@ -44,7 +42,8 @@ public class DynamoBatchReader implements Scan, Batch, SupportsReportPartitionin
             requiredColumns.add(field.name());
         }
 
-        return IntStream.range(0, connector.getTotalSegments())
+        int segments = connector.isQuery() ? 1 : connector.getTotalSegments();
+        return IntStream.range(0, segments)
                 .mapToObj(i -> new ScanPartition(i, requiredColumns, filters))
                 .toArray(InputPartition[]::new);
     }
@@ -56,9 +55,10 @@ public class DynamoBatchReader implements Scan, Batch, SupportsReportPartitionin
 
     @Override
     public Partitioning outputPartitioning() {
+        int segments = connector.isQuery() ? 1 : connector.getTotalSegments();
         return new KeyGroupedPartitioning(
                 new Expression[] { Expressions.identity(connector.getKeySchema().getHashKeyName()) },
-                connector.getTotalSegments()
+                segments
         );
     }
 }


### PR DESCRIPTION
## Summary
- enforce single-segment operation for `DynamoQueryIndexConnector` and validate `segmentNum`
- ensure batch reader plans only one partition for queries

## Testing
- `mvn -q test` *(fails: Plugin net.alchim31.maven:scala-maven-plugin:4.5.6 or one of its dependencies could not be resolved)*

------
https://chatgpt.com/codex/tasks/task_e_6898d17cb3088332967232e61e3dd5a6