### PR TITLE
Require user schema for index queries

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,19 @@
+# DynamoSource
+
+This project provides a Spark DataSource for Amazon DynamoDB.
+
+## Index queries and schema inference
+
+When querying DynamoDB tables by secondary index the connector does not attempt to infer the schema.
+Users must provide the desired schema via the `userSchema` option to avoid runtime errors.
+
+```scala
+spark.read
+  .format("dynamodb")
+  .option("tablename", "MyTable")
+  .option("indexname", "MyIndex")
+  .schema(userSchema)
+  .load()
+```
+
+Without a user supplied schema, reading from a secondary index will fail during initialization.

--- a/src/main/java/dynamodb/DynamoTable.java
+++ b/src/main/java/dynamodb/DynamoTable.java
@@ -52,7 +52,17 @@ public class DynamoTable implements Table, SupportsRead {
 
     @Override
     public StructType schema() {
-        return userSchema != null ? userSchema : inferSchema();
+        if (userSchema != null) {
+            return userSchema;
+        }
+
+        if (dynamoConnector.isQuery()) {
+            throw new IllegalArgumentException(
+                    "Schema inference is not supported for index queries. " +
+                    "Please supply `userSchema` when reading via a secondary index.");
+        }
+
+        return inferSchema();
     }
 
     @Override


### PR DESCRIPTION
## Summary
- Stop schema inference when reading from DynamoDB secondary indexes and require a user-supplied schema
- Document userSchema requirement for index queries

## Testing
- `mvn -q test` *(fails: Plugin net.alchim31.maven:scala-maven-plugin:pom:4.5.6 not resolved; Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_6898d3687f7483328f576424c261c5f9