### PR TITLE
Refactor filter pushdown with expression attribute maps

### DIFF
--- a/dependency-reduced-pom.xml
+++ b/dependency-reduced-pom.xml
@@ -82,6 +82,12 @@
       <version>2.4.4</version>
       <scope>provided</scope>
     </dependency>
+    <dependency>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter</artifactId>
+      <version>5.10.2</version>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
   <properties>
     <scala.version>2.12.18</scala.version>

--- a/src/test/java/dynamodb/FilterPushdownTest.java
+++ b/src/test/java/dynamodb/FilterPushdownTest.java
@@ -1,0 +1,31 @@
+import org.junit.jupiter.api.Test;
+import org.apache.spark.sql.sources.EqualTo;
+import org.apache.spark.sql.sources.Filter;
+import software.amazon.awssdk.services.dynamodb.model.AttributeValue;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+public class FilterPushdownTest {
+
+    @Test
+    public void testReservedWordAttributeName() {
+        Filter[] filters = new Filter[]{new EqualTo("size", "L")};
+        FilterPushdown.Result result = FilterPushdown.apply(filters);
+        assertEquals("(#n0 = :v0)", result.getExpression());
+        assertEquals("size", result.getExpressionAttributeNames().get("#n0"));
+        AttributeValue value = result.getExpressionAttributeValues().get(":v0");
+        assertNotNull(value);
+        assertEquals("L", value.s());
+    }
+
+    @Test
+    public void testSpecialCharacterAttributeName() {
+        Filter[] filters = new Filter[]{new EqualTo("user-name", "Bob")};
+        FilterPushdown.Result result = FilterPushdown.apply(filters);
+        assertEquals("(#n0 = :v0)", result.getExpression());
+        assertEquals("user-name", result.getExpressionAttributeNames().get("#n0"));
+        AttributeValue value = result.getExpressionAttributeValues().get(":v0");
+        assertNotNull(value);
+        assertEquals("Bob", value.s());
+    }
+}


### PR DESCRIPTION
## Summary
- return expression, attribute name map, and value map from `FilterPushdown`
- populate expression attribute maps in DynamoDB query and scan connectors
- add tests covering reserved words and special characters

## Testing
- `mvn -q test` *(fails: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_6898d9d3ddd08332ae4b360ebdce5c66