### PR TITLE
docs: add Docker Compose setup for local development

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,11 +1,65 @@
 # DynamoSource
 
-This project provides a Spark DataSource for Amazon DynamoDB.
+Spark DataSource for Amazon DynamoDB.
+
+## Prerequisites
+
+- Java 8+
+- Maven 3.x
+- Docker and Docker Compose
+
+## Build
+
+```bash
+mvn package
+```
+
+The packaged connector will be available at `target/spark-dynamodb-datasource-1.0-SNAPSHOT.jar`.
+
+## Run locally with Docker Compose
+
+The repository provides a `docker-compose.yml` that starts a local DynamoDB emulator and a Spark container.
+
+1. **Start the environment**
+
+   ```bash
+   docker compose up -d
+   ```
+
+2. **Build the connector** (if not already built)
+
+   ```bash
+   mvn package
+   ```
+
+3. **Open a Spark shell** inside the running Spark container and include the connector JAR:
+
+   ```bash
+   docker compose exec spark spark-shell \
+     --master local[*] \
+     --jars /workspace/target/spark-dynamodb-datasource-1.0-SNAPSHOT.jar
+   ```
+
+4. **Read from DynamoDB Local**
+
+   ```scala
+   spark.read
+     .format("dynamodb")
+     .option("endpoint", "http://dynamodb:8000")
+     .option("region", "us-east-1")
+     .option("tablename", "MyTable")
+     .load()
+   ```
+
+5. **Stop the services**
+
+   ```bash
+   docker compose down
+   ```
 
 ## Index queries and schema inference
 
-When querying DynamoDB tables by secondary index the connector does not attempt to infer the schema.
-Users must provide the desired schema via the `userSchema` option to avoid runtime errors.
+When querying DynamoDB tables by secondary index the connector does not attempt to infer the schema. Users must provide the desired schema via the `userSchema` option to avoid runtime errors.
 
 ```scala
 spark.read
@@ -16,4 +70,35 @@ spark.read
   .load()
 ```
 
+### Example
+
+```scala
+import org.apache.spark.sql.types._
+
+val userSchema = StructType(Seq(
+  StructField("pk", StringType),
+  StructField("sk", StringType),
+  StructField("attribute", StringType)
+))
+
+spark.read
+  .format("dynamodb")
+  .option("endpoint", "http://dynamodb:8000")
+  .option("region", "us-east-1")
+  .option("tablename", "MyTable")
+  .option("indexname", "MyIndex")
+  .schema(userSchema)
+  .load()
+  .show()
+```
+
 Without a user supplied schema, reading from a secondary index will fail during initialization.
+
+## Testing
+
+Run unit tests with:
+
+```bash
+mvn test
+```
+

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,22 @@
+version: "3.8"
+
+services:
+  dynamodb:
+    image: amazon/dynamodb-local:latest
+    container_name: dynamodb-local
+    ports:
+      - "8000:8000"
+    command: -jar DynamoDBLocal.jar -sharedDb -inMemory
+
+  spark:
+    image: bitnami/spark:3.5.1
+    container_name: spark
+    environment:
+      - SPARK_MODE=master
+    volumes:
+      - .:/workspace
+    depends_on:
+      - dynamodb
+    ports:
+      - "4040:4040"
+    command: sleep infinity


### PR DESCRIPTION
## Summary
- document building and running with Docker Compose
- add example of querying a secondary index with a user-provided schema
- add docker-compose.yml providing DynamoDB Local and Spark services

## Testing
- `mvn -q test` *(fails: Plugin net.alchim31.maven:scala-maven-plugin:4.5.6 or one of its dependencies could not be resolved: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_6898dbed7a308332b9aa91f6f6112ae4